### PR TITLE
Update README to fix missing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ dfx canister --help
 If you want to test your project locally, you can use the following commands:
 
 ```bash
-# Starts the replica, running in the background
-dfx start --background
-
 # Install dependencies
 npm install
+
+# Install Vessel which is a dependency
+https://github.com/dfinity/vessel:
 
 npm run dev
 


### PR DESCRIPTION
Updates the documentation to add missing instructions about install vessel.

Also removes the dfx start --background command since that is included as part of the ```npm run dev``` command