### PR TITLE
Add fix for the explore web page

### DIFF
--- a/NotesOnLocalDev.md
+++ b/NotesOnLocalDev.md
@@ -7,8 +7,8 @@ Network: http://172.30.141.44:3000/
 but http://localhost:3000/ doesn't work for me
 you could try uncommenting the block comment for the proxy in vite.config.ts (right under the comment with Local vs Mainnet Development) and see if that works for you
 
-http://172.30.141.44:3000/ runs for me (i.e. shows the UI) but cannot access the backend canister. That's the error about the call to the backend canister being rejected and it saying something about the called function not being defined on the backend canister. It's not an issue with the backend canister but as far as I can see the call to the local IC replica is rejected (either because the UI isn't allowed to call the local IC replica or because it's running somewhere else). So e.g. the calls for creating a new space or loading a user's spaces on the landing page don't work.
-but accessing e.g. the testroom page works (as the backend canister isn't involved): http://172.30.141.44:3000/#/testroom
+Currently http://172.29.55.198:3000/ from the hot reloading npm run vite is able to access the backend cansiter. The system seems to be able to call the replica and load rooms from the canisters 
+
 
 Working with the UI spun up by npm run vite has the advantage that it supports hot reloading for changes made to the UI so one doesn't need to redeploy on every UI change.
 that's not the case for the UI canister spun up with 

--- a/NotesOnLocalDev.md
+++ b/NotesOnLocalDev.md
@@ -7,7 +7,7 @@ Network: http://172.30.141.44:3000/
 but http://localhost:3000/ doesn't work for me
 you could try uncommenting the block comment for the proxy in vite.config.ts (right under the comment with Local vs Mainnet Development) and see if that works for you
 
-Currently http://172.29.55.198:3000/ from the hot reloading npm run vite is able to access the backend cansiter. The system seems to be able to call the replica and load rooms from the canisters 
+Currently http://172.29.55.198:3000/ from the hot reloading npm run vite is able to access the backend cansiter. The system seems to be able to call the replica and load rooms from the canisters. To get it to work you need to run npm run dev which starts the backend canister, the downside is that the hot relating links will call the deployed canisters from npm run dev which means that those pages are not hot reloading. But at least the calls work
 
 
 Working with the UI spun up by npm run vite has the advantage that it supports hot reloading for changes made to the UI so one doesn't need to redeploy on every UI change.

--- a/src/PersonalWebSpace_frontend/pages/ExploreSpaces.svelte
+++ b/src/PersonalWebSpace_frontend/pages/ExploreSpaces.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { PersonalWebSpace_backend } from "canisters/PersonalWebSpace_backend";
+  import { store } from "../store";
   
   import Topnav from "../components/Topnav.svelte";
   import Footer from "../components/Footer.svelte";
@@ -15,7 +16,7 @@
   const loadUserSpaces = async () => {
     let requestPromises = [];
     for (var i = 0; i < numberOfRandomSpacesToLoad; i++) {
-      requestPromises.push(PersonalWebSpace_backend.getRandomSpace()); // Send requests in parallel and then await all to speed up
+      requestPromises.push($store.backendActor.getRandomSpace()); // Send requests in parallel and then await all to speed up
     };
     const spaceNFTResponses = await Promise.all(requestPromises);
     let randomSpaces = [];


### PR DESCRIPTION
This PR fixes an issue where the explore page was not able to load on local development. Since I copied the same method that is used in the intro page
<img width="437" alt="image" src="https://user-images.githubusercontent.com/10234268/225170345-1df1523b-5d27-497e-a03b-03a2e93bb993.png">
This method should work on the mainnet too

Also npm run vite hot reloading is now communicating with the backend canister. You should give it a try to see if it does too but it is nice that it works now
<img width="600" alt="image" src="https://user-images.githubusercontent.com/10234268/225170419-80370e81-361f-452e-929f-e3a042cb0f3f.png">

Before making the fix I was getting these errors:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/10234268/225170647-167dbeca-bd1c-47e4-85f2-6598fb1da9c2.png">
